### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/external/source/shellcode/windows/x64/build.py
+++ b/external/source/shellcode/windows/x64/build.py
@@ -30,36 +30,36 @@ def locate( src_file, dir="./src/" ):
   return None
 #=============================================================================#
 def build( name ):
-  location = locate( "%s.asm" % name )
+  location = locate( "{0!s}.asm".format(name) )
   if location:
     input = os.path.normpath( os.path.join( location, name ) )
     output = os.path.normpath( os.path.join( "./bin/", name ) )
-    p = Popen( ["nasm", "-f bin", "-O3", "-o %s.bin" % output, "%s.asm" % input ] )
+    p = Popen( ["nasm", "-f bin", "-O3", "-o {0!s}.bin".format(output), "{0!s}.asm".format(input) ] )
     p.wait()
     xmit( name )
   else:
-    print "[-] Unable to locate '%s.asm' in the src directory" % name
+    print "[-] Unable to locate '{0!s}.asm' in the src directory".format(name)
 #=============================================================================#
 def xmit_dump_ruby( data, length=16 ):
   dump = ""
   for i in xrange( 0, len( data ), length ):
     bytes = data[ i : i+length ]
-    hex = "\"%s\"" % ( ''.join( [ "\\x%02X" % ord(x) for x in bytes ] ) )
+    hex = "\"{0!s}\"".format(( ''.join( [ "\\x{0:02X}".format(ord(x)) for x in bytes ] ) ))
     if i+length <= len(data):
       hex += " +"
-    dump += "%s\n" % ( hex )
+    dump += "{0!s}\n".format(( hex ))
   print dump
 #=============================================================================#
 def xmit_offset( data, name, value ):
   offset = data.find( value );
   if offset != -1:
-    print "# %s Offset: %d" % ( name, offset )
+    print "# {0!s} Offset: {1:d}".format(name, offset )
 #=============================================================================#
 def xmit( name, dump_ruby=True ):
-  bin = os.path.normpath( os.path.join( "./bin/", "%s.bin" % name ) )
+  bin = os.path.normpath( os.path.join( "./bin/", "{0!s}.bin".format(name) ) )
   f = open( bin, 'rb')
   data = f.read()
-  print "# Name: %s\n# Length: %d bytes" % ( name, len( data ) )
+  print "# Name: {0!s}\n# Length: {1:d} bytes".format(name, len( data ) )
   xmit_offset( data, "Port", pack( ">H", 4444 ) )           # 4444
   xmit_offset( data, "Host", pack( ">L", 0x7F000001 ) )     # 127.0.0.1
   xmit_offset( data, "ExitFunk", pack( "<L", 0x0A2A1DE0 ) ) # kernel32.dll!ExitThread
@@ -76,7 +76,7 @@ def main( argv=None ):
     if len( argv ) == 1:
       print "Usage: build.py [clean|all|<name>]"
     else:
-      print "# Built on %s\n" % (  time.asctime( time.localtime() ) )
+      print "# Built on {0!s}\n".format((  time.asctime( time.localtime() ) ))
       if argv[1] == "clean":
         clean()
       elif argv[1] == "all":

--- a/external/source/shellcode/windows/x86/build.py
+++ b/external/source/shellcode/windows/x86/build.py
@@ -30,39 +30,39 @@ def locate( src_file, dir="./src/" ):
 
 #=============================================================================#
 def build( name ):
-	location = locate( "%s.asm" % name )
+	location = locate( "{0!s}.asm".format(name) )
 	if location:
 		input = os.path.normpath( os.path.join( location, name ) )
 		output = os.path.normpath( os.path.join( "./bin/", name ) )
-		p = Popen( ["nasm", "-f bin", "-O3", "-o %s.bin" % output, "%s.asm" % input ] )
+		p = Popen( ["nasm", "-f bin", "-O3", "-o {0!s}.bin".format(output), "{0!s}.asm".format(input) ] )
 		p.wait()
 		xmit( name )
 	else:
-		print "[-] Unable to locate '%s.asm' in the src directory" % name
+		print "[-] Unable to locate '{0!s}.asm' in the src directory".format(name)
 
 #=============================================================================#
 def xmit_dump_ruby( data, length=16 ):
 	dump = ""
 	for i in xrange( 0, len( data ), length ):
 		bytes = data[ i : i+length ]
-		hex = "\"%s\"" % ( ''.join( [ "\\x%02X" % ord(x) for x in bytes ] ) )
+		hex = "\"{0!s}\"".format(( ''.join( [ "\\x{0:02X}".format(ord(x)) for x in bytes ] ) ))
 		if i+length <= len(data):
 			hex += " +"
-		dump += "%s\n" % ( hex )
+		dump += "{0!s}\n".format(( hex ))
 	print dump
 
 #=============================================================================#
 def xmit_offset( data, name, value, match_offset=0 ):
 	offset = data.find( value );
 	if offset != -1:
-		print "# %s Offset: %d" % ( name, offset + match_offset )
+		print "# {0!s} Offset: {1:d}".format(name, offset + match_offset )
 
 #=============================================================================#
 def xmit( name, dump_ruby=True ):
-	bin = os.path.normpath( os.path.join( "./bin/", "%s.bin" % name ) )
+	bin = os.path.normpath( os.path.join( "./bin/", "{0!s}.bin".format(name) ) )
 	f = open( bin, 'rb')
 	data = f.read()
-	print "# Name: %s\n# Length: %d bytes" % ( name, len( data ) )
+	print "# Name: {0!s}\n# Length: {1:d} bytes".format(name, len( data ) )
 	xmit_offset( data, "Port", pack( ">H", 4444 ) )           # 4444
 	xmit_offset( data, "LEPort", pack( "<H", 4444 ) )         # 4444
 	xmit_offset( data, "Host", pack( ">L", 0x7F000001 ) )     # 127.0.0.1
@@ -84,7 +84,7 @@ def xmit( name, dump_ruby=True ):
 	if( name.find( "egghunter" ) >= 0 ):
 		null_count = data.count( "\x00" )
 		if( null_count > 0 ):
-			print "# Note: %d NULL bytes found." % ( null_count )
+			print "# Note: {0:d} NULL bytes found.".format(( null_count ))
 	if dump_ruby:
 		xmit_dump_ruby( data )
 
@@ -96,7 +96,7 @@ def main( argv=None ):
 		if len( argv ) == 1:
 			print "Usage: build.py [clean|all|<name>]"
 		else:
-			print "# Built on %s\n" % (  time.asctime( time.localtime() ) )
+			print "# Built on {0!s}\n".format((  time.asctime( time.localtime() ) ))
 			if argv[1] == "clean":
 				clean()
 			elif argv[1] == "all":

--- a/external/source/shellcode/windows/x86/src/hash.py
+++ b/external/source/shellcode/windows/x86/src/hash.py
@@ -82,7 +82,7 @@ def hash( module, function, bits=13, print_hash=True ):
     function_hash += ord( c )
   h = module_hash + function_hash & 0xFFFFFFFF
   if print_hash:
-    print "[+] 0x%08X = %s!%s" % ( h, module.lower(), function )
+    print "[+] 0x{0:08X} = {1!s}!{2!s}".format(h, module.lower(), function )
   return h
 #=============================================================================#
 def scan( dll_path, dll_name, print_hashes=False, print_collisions=True ):
@@ -97,7 +97,7 @@ def scan( dll_path, dll_name, print_hashes=False, print_collisions=True ):
         continue
       h = hash( dll_name, export.name, print_hash=print_hashes )
       for ( col_hash, col_name ) in collisions:
-        if col_hash == h and col_name != "%s!%s" % (dll_name, export.name):
+        if col_hash == h and col_name != "{0!s}!{1!s}".format(dll_name, export.name):
           if h not in collisions_detected.keys():
             collisions_detected[h] = []
           collisions_detected[h].append( (dll_path, dll_name, export.name) )
@@ -111,16 +111,16 @@ def scan_directory( dir ):
     for file_name in files:
       if file_name[-4:] == ".dll":# or file_name[-4:] == ".exe":
         scan( dot, file_name )
-  print "\n[+] Found %d Collisions.\n" % ( len(collisions_detected) )
+  print "\n[+] Found {0:d} Collisions.\n".format(( len(collisions_detected) ))
   for h in collisions_detected.keys():
     for (col_hash, col_name ) in collisions:
       if h == col_hash:
         detected_name = col_name
         break
-    print "[!] Collision detected for 0x%08X (%s):" % ( h, detected_name )
+    print "[!] Collision detected for 0x{0:08X} ({1!s}):".format(h, detected_name )
     for (collided_dll_path, collided_dll_name, collided_export_name) in collisions_detected[h]:
-      print "\t%s!%s (%s)" % ( collided_dll_name, collided_export_name, collided_dll_path )
-  print "\n[+] Scanned %d exported functions via %d modules.\n" % ( functions_scanned, modules_scanned )
+      print "\t{0!s}!{1!s} ({2!s})".format(collided_dll_name, collided_export_name, collided_dll_path )
+  print "\n[+] Scanned {0:d} exported functions via {1:d} modules.\n".format(functions_scanned, modules_scanned )
 #=============================================================================#
 def main( argv=None ):
   if not argv:
@@ -129,12 +129,12 @@ def main( argv=None ):
     if len( argv ) == 1:
       print "Usage: hash.py [/dir <path>] | [/mod <path> <module.dll>] | [<module.dll> <function>]"
     else:
-      print "[+] Ran on %s\n" % (  time.asctime( time.localtime() ) )
+      print "[+] Ran on {0!s}\n".format((  time.asctime( time.localtime() ) ))
       if argv[1] == "/dir":
-        print "[+] Scanning directory '%s' for collisions..." % argv[2]
+        print "[+] Scanning directory '{0!s}' for collisions...".format(argv[2])
         scan_directory( argv[2] )
       elif argv[1] == "/mod":
-        print "[+] Scanning module '%s' in directory '%s'..." % ( argv[3], argv[2] )
+        print "[+] Scanning module '{0!s}' in directory '{1!s}'...".format(argv[3], argv[2] )
         scan( argv[2], argv[3], print_hashes=True )
       else:
         hash( argv[1], argv[2] )


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:metasploit-framework?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:metasploit-framework?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
